### PR TITLE
Add git push troubleshooting guidance to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
 # kortana
-i am who i am
+
+## Project status
+
+At the moment this repository only contains a short README and no source
+code, datasets, model checkpoints, or documentation describing a working
+assistant.  There are no build scripts or tests either.  Because of this the
+project is not even close to an "alive" Kor'tana-like intelligence.
+
+## What would be needed next
+
+To move toward something resembling a living virtual assistant you would need
+to add, at minimum:
+
+1. **Design documents** that define the assistant's capabilities, tone, and
+   interaction model.
+2. **Implementation code** (e.g., a web service, voice interface, or game
+   integration) backed by natural-language understanding and reasoning
+   components.
+3. **Data and evaluation pipelines** so you can iteratively train, test, and
+   improve the system.
+4. **Safety, privacy, and alignment considerations** to keep interactions
+   respectful and secure.
+
+Until those foundational pieces exist, the project remains an empty shell and
+does not demonstrate any evidence of a living assistant.
+
+## Keeping changes in sync with GitHub
+
+If you are new to Git or GitHub it can feel like pushes do not show up right
+away. The checklist below outlines a typical workflow and how to confirm that
+each step succeeded:
+
+1. **Make local changes** and confirm they appear in `git status`.
+2. **Commit locally** with `git commit -am "message"` (or stage with
+   `git add` first). After this, `git log -1` should show your new commit.
+3. **Push to the remote** using `git push origin main` (replace `main` with
+   the branch name you are using). Git will print a summary and the URL of the
+   updated branch when the push completes.
+4. **Verify on GitHub** by refreshing the repository page or checking the
+   "Commits" tab. Sometimes GitHub caches pages for a few seconds—waiting a
+   moment or performing a hard refresh (Ctrl+Shift+R) usually reveals the new
+   commit.
+
+If a push seems to hang or the new commit does not appear, run
+`git status` to make sure your local branch is ahead of the remote and
+`git remote -v` to confirm you are pushing to the expected repository. In
+collaborative scenarios, running `git pull --rebase origin main` before
+pushing keeps your branch up to date and prevents rejected pushes.


### PR DESCRIPTION
## Summary
- document a step-by-step workflow for keeping local changes in sync with GitHub
- add troubleshooting tips for common push and refresh issues

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68d85c2a14bc8325b1e679b9983bc611